### PR TITLE
Don't size the fallback terrain buffer from all available vram

### DIFF
--- a/src/main/java/me/cortex/nvidium/NvidiumWorldRenderer.java
+++ b/src/main/java/me/cortex/nvidium/NvidiumWorldRenderer.java
@@ -123,8 +123,16 @@ public class NvidiumWorldRenderer {
 
     private void update_allowed_memory() {
         if (Nvidium.config.automatic_memory) {
-            max_geometry_memory = (glGetInteger(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX) / 1024) + (sectionManager==null?0:sectionManager.terrainAreana.getMemoryUsed()/(1024*1024));
-            max_geometry_memory -= 1024;//Minus 1gb of vram
+            long available_memory = (glGetInteger(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX) / 1024) + (sectionManager==null?0:sectionManager.terrainAreana.getMemoryUsed()/(1024*1024));
+            if (Nvidium.SUPPORTS_PERSISTENT_SPARSE_ADDRESSABLE_BUFFER) {
+                max_geometry_memory = available_memory - 1024;//Minus 1gb of vram
+            } else {
+                //The fallback buffer is fully committed when it is created, so it must stay well
+                // under the available vram instead of claiming all but 1gb of it. Terrain geometry
+                // is only a few hundred mb at normal render distances and overflowing the arena
+                // just evicts regions, so this is deliberately conservative
+                max_geometry_memory = Math.min(available_memory/4, 3072);
+            }
             max_geometry_memory = Math.max(2048, max_geometry_memory);//Minimum 2 gb of vram
         } else {
             max_geometry_memory = Nvidium.config.max_geometry_memory;


### PR DESCRIPTION

<img width="2557" height="1366" alt="Screenshot_20260831_012908" src="https://github.com/user-attachments/assets/8ec2fd81-808b-42cc-ae4b-bd183aaa7402" />
Fixes #74. Related to #44.

On linux, `automatic_memory` sizes the terrain buffer at `available vram - 1gb`. On the sparse path that number is only a soft limit used to decide when to cull regions, and the underlying buffer is a fixed 80gb sparse allocation, so claiming nearly all of vram is harmless. On linux sparse buffers are disabled, so the same value instead becomes the size of a `DeviceOnlyMappedBuffer` that is committed and made resident up front. On a 24gb card that means asking the driver to pin ~20gb before the first frame, which fails the mapping and stalls the entire system while loading a world.

**The sparse path is untouched.** The change lives entirely inside the `else` branch of `SUPPORTS_PERSISTENT_SPARSE_ADDRESSABLE_BUFFER`, which is only ever false on linux, and the sparse branch reproduces the previous expression exactly. Behaviour off linux is unchanged, so this does not need a linux machine to be reviewed safely.

### Why not just pick a bigger fraction

Terrain demand is driven by render distance, not by how much vram the card has. At render distance 16 the terrain used **208mb of a 4408mb buffer** — the heuristic was scaling the allocation to a quantity unrelated to the demand. A 6gb card and a 24gb card at the same render distance need the same amount.

Overflowing the arena only evicts regions via `removeARegion()`, while overshooting exhausts driver VA space and hangs the machine. Those failure modes are not symmetric, so this sizes conservatively: a quarter of available vram, capped at 3072mb, keeping the existing 2048mb floor.

### Measurements

RTX 4090, driver 610.57.04. NVRM errors counted from `journalctl` at the moment the buffer is allocated:

| terrain buffer | NVRM mapping errors / run | join → first render |
|---|---|---|
| ~20000mb (stock `automatic_memory`) | ~2200 | 49s, or never finished |
| 4408mb (`/3`, cap 8192) | 78 | 1s |
| **3072mb (this patch)** | **0** | **<1s** |

Kernel signature when oversized, matching #74:

```
NVRM: dmaAllocMapping_GM107: can't alloc VA space for mapping.
NVRM: nvAssertOkFailedNoLog: Out of memory [NV_ERR_NO_MEMORY]
```

Headroom at higher render distance, from the in-game `Mem (fallback): used/limit` readout:

| render distance | terrain used | of cap |
|---|---|---|
| 16 | 208mb | 3072mb |
| 32 | 1136mb | 3072mb |

Render distances beyond ~48 will reach the cap and begin evicting regions. That is visible but recoverable, unlike the hang it replaces, and `automatic_memory: false` with a manual `max_geometry_memory` is unchanged for anyone who wants more.

### What was not tested

- Windows — the changed branch is unreachable there by construction
- Values between 3072mb and 4408mb
- Cards other than a 24gb RTX 4090; the reporters in #74 and #44 have 6–16gb cards and could confirm the smaller end

### Environment

- RTX 4090 24GB, NVIDIA 610.57.04, Arch Linux (kernel 7.1.9), KDE Plasma / Wayland
- Minecraft 26.2, Fabric Loader 0.19.3, Sodium 0.9.1+mc26.2, Nvidium 0.4.4-beta5-26.2
